### PR TITLE
Test: Tune tests to support MS Windows

### DIFF
--- a/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseSingleMixIn.scala
+++ b/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseSingleMixIn.scala
@@ -27,6 +27,8 @@ import org.testcontainers.utility.{DockerImageName, MountableFile}
 
 import java.nio.file.{Path, Paths}
 
+import scala.collection.JavaConverters._
+
 trait ClickHouseSingleMixIn extends AnyFunSuite with ForAllTestContainer {
   // format: off
   val CLICKHOUSE_IMAGE:    String = Utils.load("CLICKHOUSE_IMAGE", "clickhouse/clickhouse-server:23.8")
@@ -43,13 +45,16 @@ trait ClickHouseSingleMixIn extends AnyFunSuite with ForAllTestContainer {
   protected val rootProjectDir: Path = {
     val thisClassURI = this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI
     val currentPath = Paths.get(thisClassURI).toAbsolutePath.normalize
-    val coreModuleIndex = currentPath.toString.indexOf("/clickhouse-core")
+    val eachFolder = currentPath.iterator().asScala.toIndexedSeq
+    val coreModuleIndex = eachFolder.indexWhere(_.toString.startsWith("clickhouse-core"))
+    val sparkModuleIndex = eachFolder.indexWhere(_.toString.startsWith("clickhouse-spark"))
+    require(coreModuleIndex > 0 || sparkModuleIndex > 0, s"illegal path: $currentPath")
     if (coreModuleIndex > 0) {
-      Paths.get(currentPath.toString.substring(0, coreModuleIndex))
-    } else {
-      val sparkModuleIndex = currentPath.toString.indexOf("/clickhouse-spark")
-      require(sparkModuleIndex > 0, s"illegal path: $currentPath")
-      Paths.get(currentPath.toString.substring(0, sparkModuleIndex)).getParent
+      eachFolder.take(coreModuleIndex).reduce((acc, i) => acc.resolve(i))
+    } else if (sparkModuleIndex > 0) {
+      eachFolder.take(sparkModuleIndex).dropRight(1).reduce((acc, i) => acc.resolve(i))
+    } else { // unreachable code
+      throw new IllegalArgumentException(s"illegal path: $currentPath")
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

This PR aims to tune the code to make the test runnable on Microsoft Windows.

Unfortunately, my MacBook got damaged and I have to use a Windows machine these days, when I try to run the test with `.\gradlew.bat clean test`, I get the following errors

```
xenon.clickhouse.HashSuite *** ABORTED *** (0 milliseconds)
  java.lang.RuntimeException: Unable to load a Suite class xenon.clickhouse.HashSuite that was discovered in the runpath: requirement failed: illegal path: D:\Projects\spark-clickhouse-connector\clickhouse-core-it\build\classes\scala\test      
  at org.scalatest.tools.DiscoverySuite$.getSuiteInstance(DiscoverySuite.scala:80)
  at org.scalatest.tools.DiscoverySuite.$anonfun$nestedSuites$1(DiscoverySuite.scala:38)
  at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
  at scala.collection.Iterator.foreach(Iterator.scala:943)
  at scala.collection.Iterator.foreach$(Iterator.scala:943)
  at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
  at scala.collection.IterableLike.foreach(IterableLike.scala:74)
  at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
  at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
  at scala.collection.TraversableLike.map(TraversableLike.scala:286)
```

this is because Windows uses backslash as the path separator while UNIX-like OS uses the slash, it can be easily fixed by replacing path string match with Java NIO methods.

for developers who want to run tests on Windows, you need to:

1. install JDK 8 or 11 or 17 - download and unarchive a JDK tarball, set env `JAVA_HOME` and add `%JAVA_HOME%\bin` to `PATH`
2. install Hadoop [winutils](https://github.com/steveloughran/winutils) - just clone the repo and set `HADOOP_HOME` to `the-path-of\hadoop-3.0.0`
3. install [Docker Desktop](https://www.docker.com/products/docker-desktop/)

after applying patch, I can run tests successfully

```
 .\gradlew.bat clean test

...

Tests: succeeded 74, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

BUILD SUCCESSFUL in 4m 18s
26 actionable tasks: 26 executed
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials