### PR TITLE
Fixed ReplacingMergeTree EngineSpec parsing: is_deleted column presence caused error

### DIFF
--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
@@ -103,6 +103,7 @@ class AstVisitor extends ClickHouseSQLBaseVisitor[AnyRef] with Logging {
         ReplacingMergeTreeEngineSpec(
           engine_clause = engineExpr,
           version_column = engineArgs.lift(0).map(_.asInstanceOf[FieldRef]),
+          is_deleted_column = engineArgs.lift(1).map(_.asInstanceOf[FieldRef]),
           _sorting_key = tupleIfNeeded(orderByOpt.toList),
           _primary_key = tupleIfNeeded(pkOpt.toList),
           _partition_key = tupleIfNeeded(partOpt.toList),
@@ -127,7 +128,8 @@ class AstVisitor extends ClickHouseSQLBaseVisitor[AnyRef] with Logging {
           engine_clause = engineExpr,
           zk_path = engineArgs.head.asInstanceOf[StringLiteral].value,
           replica_name = engineArgs(1).asInstanceOf[StringLiteral].value,
-          version_column = seqToOption(engineArgs.drop(2)).map(_.asInstanceOf[FieldRef]),
+          version_column = engineArgs.lift(2).map(_.asInstanceOf[FieldRef]),
+          is_deleted_column = engineArgs.lift(3).map(_.asInstanceOf[FieldRef]),
           _sorting_key = tupleIfNeeded(orderByOpt.toList),
           _primary_key = tupleIfNeeded(pkOpt.toList),
           _partition_key = tupleIfNeeded(partOpt.toList),

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
@@ -102,7 +102,7 @@ class AstVisitor extends ClickHouseSQLBaseVisitor[AnyRef] with Logging {
       case eg: String if "ReplacingMergeTree" equalsIgnoreCase eg =>
         ReplacingMergeTreeEngineSpec(
           engine_clause = engineExpr,
-          version_column = seqToOption(engineArgs).map(_.asInstanceOf[FieldRef]),
+          version_column = engineArgs.lift(0).map(_.asInstanceOf[FieldRef]),
           _sorting_key = tupleIfNeeded(orderByOpt.toList),
           _primary_key = tupleIfNeeded(pkOpt.toList),
           _partition_key = tupleIfNeeded(partOpt.toList),

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/spec/TableEngineSpec.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/spec/TableEngineSpec.scala
@@ -88,6 +88,7 @@ case class ReplicatedMergeTreeEngineSpec(
 case class ReplacingMergeTreeEngineSpec(
   engine_clause: String,
   version_column: Option[FieldRef] = None,
+  is_deleted_column: Option[FieldRef] = None,
   var _sorting_key: TupleExpr = TupleExpr(List.empty),
   var _primary_key: TupleExpr = TupleExpr(List.empty),
   var _partition_key: TupleExpr = TupleExpr(List.empty),
@@ -109,6 +110,7 @@ case class ReplicatedReplacingMergeTreeEngineSpec(
   zk_path: String,
   replica_name: String,
   version_column: Option[FieldRef] = None,
+  is_deleted_column: Option[FieldRef] = None,
   var _sorting_key: TupleExpr = TupleExpr(List.empty),
   var _primary_key: TupleExpr = TupleExpr(List.empty),
   var _partition_key: TupleExpr = TupleExpr(List.empty),

--- a/clickhouse-core/src/test/scala/com/clickhouse/spark/parse/SQLParserSuite.scala
+++ b/clickhouse-core/src/test/scala/com/clickhouse/spark/parse/SQLParserSuite.scala
@@ -83,6 +83,20 @@ class SQLParserSuite extends AnyFunSuite {
     assert(actual === expected)
   }
 
+  test("parse ReplacingMergeTree - 3") {
+    val ddl = "ReplacingMergeTree(ts, is_deleted) " +
+      "PARTITION BY toYYYYMM(created) ORDER BY id SETTINGS index_granularity = 8192"
+    val actual = parser.parseEngineClause(ddl)
+    val expected = ReplacingMergeTreeEngineSpec(
+      engine_clause = "ReplacingMergeTree(ts, is_deleted)",
+      version_column = Some(FieldRef("ts")),
+      _sorting_key = TupleExpr(FieldRef("id") :: Nil),
+      _partition_key = TupleExpr(List(FuncExpr("toYYYYMM", List(FieldRef("created"))))),
+      _settings = Map("index_granularity" -> "8192")
+    )
+    assert(actual === expected)
+  }
+
   test("parse ReplicatedReplacingMergeTree - 1") {
     val ddl = "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/wj_report/wj_respondent', '{replica}') " +
       "PARTITION BY toYYYYMM(created) ORDER BY id SETTINGS index_granularity = 8192"

--- a/clickhouse-core/src/test/scala/com/clickhouse/spark/parse/SQLParserSuite.scala
+++ b/clickhouse-core/src/test/scala/com/clickhouse/spark/parse/SQLParserSuite.scala
@@ -90,6 +90,7 @@ class SQLParserSuite extends AnyFunSuite {
     val expected = ReplacingMergeTreeEngineSpec(
       engine_clause = "ReplacingMergeTree(ts, is_deleted)",
       version_column = Some(FieldRef("ts")),
+      is_deleted_column = Some(FieldRef("is_deleted")),
       _sorting_key = TupleExpr(FieldRef("id") :: Nil),
       _partition_key = TupleExpr(List(FuncExpr("toYYYYMM", List(FieldRef("created"))))),
       _settings = Map("index_granularity" -> "8192")
@@ -122,6 +123,25 @@ class SQLParserSuite extends AnyFunSuite {
       zk_path = "/clickhouse/tables/{shard}/wj_report/wj_respondent",
       replica_name = "{replica}",
       version_column = Some(FieldRef("ts")),
+      _sorting_key = TupleExpr(FieldRef("id") :: Nil),
+      _partition_key = TupleExpr(List(FuncExpr("toYYYYMM", List(FieldRef("created"))))),
+      _settings = Map("index_granularity" -> "8192")
+    )
+    assert(actual === expected)
+  }
+
+  test("parse ReplicatedReplacingMergeTree - 3") {
+    val ddl = "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/wj_report/wj_respondent', '{replica}', " +
+      "ts, is_deleted) PARTITION BY toYYYYMM(created) ORDER BY id SETTINGS index_granularity = 8192"
+    val actual = parser.parseEngineClause(ddl)
+    val expected = ReplicatedReplacingMergeTreeEngineSpec(
+      engine_clause =
+        "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/wj_report/wj_respondent', '{replica}', " +
+          "ts, is_deleted)",
+      zk_path = "/clickhouse/tables/{shard}/wj_report/wj_respondent",
+      replica_name = "{replica}",
+      version_column = Some(FieldRef("ts")),
+      is_deleted_column = Some(FieldRef("is_deleted")),
       _sorting_key = TupleExpr(FieldRef("id") :: Nil),
       _partition_key = TupleExpr(List(FuncExpr("toYYYYMM", List(FieldRef("created"))))),
       _settings = Map("index_granularity" -> "8192")


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Column for marking rows as deleted ([**is_deleted** column](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree#is_deleted)) of **ReplacingMergeTree**  was not anyhow handled during EngineSpec parsing resulting in runtime exception like below:

```
java.lang.IllegalArgumentException: Expect list size 0 or 1, but got 2
at xenon.clickhouse.parse.ParseUtils$.seqToOption(ParseUtils.scala:32)
at xenon.clickhouse.parse.AstVisitor.visitEngineClause(AstVisitor.scala:78)
at xenon.clickhouse.parse.SQLParser.$anonfun$parseEngineClause$1(SQLParser.scala:30)
at xenon.clickhouse.parse.SQLParser.parse(SQLParser.scala:49)
at xenon.clickhouse.parse.SQLParser.parseEngineClause(SQLParser.scala:30)
at xenon.clickhouse.spec.TableEngineUtils$.resolveTableEngine(TableEngineUtils.scala:24)
at xenon.clickhouse.ClickHouseCatalog.loadTable(ClickHouseCatalog.scala:133)
at xenon.clickhouse.ClickHouseCatalog.loadTable(ClickHouseCatalog.scala:36)
at org.apache.spark.sql.DataFrameWriter.saveAsTable(DataFrameWriter.scala:583)
at org.apache.spark.sql.DataFrameWriter.saveAsTable(DataFrameWriter.scala:566)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
at py4j.Gateway.invoke(Gateway.java:282)
at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
at py4j.commands.CallCommand.execute(CallCommand.java:79)
at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
at java.lang.Thread.run(Thread.java:748)
```

## Checklist
Delete items not relevant to your PR:
- [X] Unit tests covering the common scenario was added