### PR TITLE
Build: Bump actions/upload-artifacts@v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
           -PmavenCentralMirror=https://maven-central.storage-download.googleapis.com/maven2/
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: log-java-${{ matrix.java }}-spark-${{ matrix.spark }}-scala-${{ matrix.scala }}
           path: |
@@ -73,7 +73,7 @@ jobs:
           -PmavenCentralMirror=https://maven-central.storage-download.googleapis.com/maven2/
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: log-clickhouse-${{ matrix.clickhouse }}
           path: |

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -50,7 +50,7 @@ jobs:
           -PmavenCentralMirror=https://maven-central.storage-download.googleapis.com/maven2/
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: log-clickhouse-cloud-spark-${{ matrix.spark }}-scala-${{ matrix.scala }}
           path: |

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -46,7 +46,7 @@ jobs:
           -PmavenCentralMirror=https://maven-central.storage-download.googleapis.com/maven2/
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: log-tpcds-spark-${{ matrix.spark }}-scala-${{ matrix.scala }}
           path: |


### PR DESCRIPTION
## Summary

Recover CI.

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials