### PR TITLE
Update supported clickhouse versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ 22.3, 22.8, 23.3, 23.8, 24.3.12, 24.6 ]
+        clickhouse: [ 25.3, 25.6, 25.7, latest ]
     env:
       CLICKHOUSE_IMAGE: clickhouse/clickhouse-server:${{ matrix.clickhouse }}
     steps:

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/clickhouse-s2r2-compose.yml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/clickhouse-s2r2-compose.yml
@@ -32,7 +32,7 @@ services:
       - ./config.xml:/etc/clickhouse-server/config.xml
       - ./remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
       - ./zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
-      - ./users.xml:/etc/clickhouse-server/users.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
       - ./s1r1/interserver_http_host.xml:/etc/clickhouse-server/config.d/interserver_http_host.xml
       - ./s1r1/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./../../../../../log/clickhouse-s1r1-server:/var/log/clickhouse-server
@@ -50,7 +50,7 @@ services:
       - ./config.xml:/etc/clickhouse-server/config.xml
       - ./remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
       - ./zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
-      - ./users.xml:/etc/clickhouse-server/users.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
       - ./s1r2/interserver_http_host.xml:/etc/clickhouse-server/config.d/interserver_http_host.xml
       - ./s1r2/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./../../../../../log/clickhouse-s1r2-server:/var/log/clickhouse-server
@@ -68,7 +68,7 @@ services:
       - ./config.xml:/etc/clickhouse-server/config.xml
       - ./remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
       - ./zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
-      - ./users.xml:/etc/clickhouse-server/users.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
       - ./s2r1/interserver_http_host.xml:/etc/clickhouse-server/config.d/interserver_http_host.xml
       - ./s2r1/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./../../../../../log/clickhouse-s2r1-server:/var/log/clickhouse-server
@@ -86,7 +86,7 @@ services:
       - ./config.xml:/etc/clickhouse-server/config.xml
       - ./remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
       - ./zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
-      - ./users.xml:/etc/clickhouse-server/users.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
       - ./s2r2/interserver_http_host.xml:/etc/clickhouse-server/config.d/interserver_http_host.xml
       - ./s2r2/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./../../../../../log/clickhouse-s2r2-server:/var/log/clickhouse-server

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/remote_servers.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/remote_servers.xml
@@ -12,7 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <remote_servers>
         <default>
             <shard>
@@ -67,4 +67,4 @@
             </shard>
         </single_replica>
     </remote_servers>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r1/interserver_http_host.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r1/interserver_http_host.xml
@@ -12,6 +12,6 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <interserver_http_host>clickhouse-s1r1</interserver_http_host>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r1/macros.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r1/macros.xml
@@ -12,9 +12,9 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <macros>
         <shard>1</shard>
         <replica>1</replica>
     </macros>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r2/interserver_http_host.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r2/interserver_http_host.xml
@@ -12,6 +12,6 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <interserver_http_host>clickhouse-s1r2</interserver_http_host>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r2/macros.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s1r2/macros.xml
@@ -12,9 +12,9 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <macros>
         <shard>1</shard>
         <replica>2</replica>
     </macros>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r1/interserver_http_host.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r1/interserver_http_host.xml
@@ -12,6 +12,6 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <interserver_http_host>clickhouse-s2r1</interserver_http_host>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r1/macros.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r1/macros.xml
@@ -12,9 +12,9 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <macros>
         <shard>2</shard>
         <replica>1</replica>
     </macros>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r2/interserver_http_host.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r2/interserver_http_host.xml
@@ -12,6 +12,6 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <interserver_http_host>clickhouse-s2r2</interserver_http_host>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r2/macros.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/s2r2/macros.xml
@@ -12,9 +12,9 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <macros>
         <shard>2</shard>
         <replica>2</replica>
     </macros>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/zookeeper.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/zookeeper.xml
@@ -12,11 +12,11 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<yandex>
+<clickhouse>
     <zookeeper>
         <node index="1">
             <host>zookeeper</host>
             <port>2181</port>
         </node>
     </zookeeper>
-</yandex>
+</clickhouse>

--- a/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseClusterMixIn.scala
+++ b/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseClusterMixIn.scala
@@ -30,7 +30,7 @@ trait ClickHouseClusterMixIn extends AnyFunSuite with ForAllTestContainer {
 
   protected val CLICKHOUSE_IMAGE: String = Utils.load(
     "CLICKHOUSE_IMAGE",
-    "clickhouse/clickhouse-server:23.8"
+    "clickhouse/clickhouse-server:25.3"
   )
 
   protected val clickhouseVersion: ClickHouseVersion = ClickHouseVersion.of(CLICKHOUSE_IMAGE.split(":").last)


### PR DESCRIPTION
## Summary
* Updated the tested versions to those supported in https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md
* Update the default ClickHouse version (in case no version provided) to `25.3`
* Remove old `<yandex>` elements
* Place the `users.xml` config in the right path when setting up a ClickHouse cluster

close #414 