### PR TITLE
ci: bump ClickHouse test matrix to 26.x stable branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ 26.4, 26.5, 26.6, 26.7, latest, head ]
+        clickhouse: [ 26.5, 26.6, 26.7, 26.8, latest, head ]
         java: [ 8, 17 ]
         scala: [ '2.12', '2.13' ]
         spark: [ '3.3', '3.4', '3.5', '4.0' ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ 25.6, 25.7, 25.8, 25.9, latest, head ]
+        clickhouse: [ 26.4, 26.5, 26.6, 26.7, latest, head ]
         java: [ 8, 17 ]
         scala: [ '2.12', '2.13' ]
         spark: [ '3.3', '3.4', '3.5', '4.0' ]


### PR DESCRIPTION
Update the pinned ClickHouse versions in the build-and-test matrix from 25.6/25.7/25.8/25.9 to the four newest stable branches 26.4/26.5/26.6/26.7, keeping the matrix size unchanged (latest and head untouched).

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials