### PR TITLE
fix(read): make Cloud reads consistent and partition listings non-authoritative

### DIFF
--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -86,6 +86,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -59,6 +59,30 @@ case class ClickHouseTable(
     with SQLHelper
     with Logging {
 
+  /**
+   * Runtime statistics are not part of a table's identity. `total_rows`, `total_bytes` and the
+   * `lifetime_*` counters move as data commits, so letting them into equality makes two catalog
+   * loads of the same table unequal. Spark compares plans to find cached data, and a
+   * DataSourceV2Relation carries this Table, so a shifting identity silently defeats plan reuse
+   * (CACHE TABLE, reused exchanges, self-join detection). They stay in `properties()`; only
+   * equality ignores them.
+   */
+  private def identityKey =
+    (
+      node,
+      cluster,
+      tz,
+      spec.copy(total_rows = None, total_bytes = None, lifetime_rows = None, lifetime_bytes = None),
+      engineSpec
+    )
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ClickHouseTable => identityKey == that.identityKey
+    case _ => false
+  }
+
+  override def hashCode(): Int = identityKey.hashCode()
+
   def database: String = spec.database
 
   def table: String = spec.name

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -233,7 +233,27 @@ class ClickHouseBatchScan(scanJob: ScanJobDescription) extends Scan with Batch
     if (partitions.length == 1) {
       log.warn(s"Reading $database.$table as a single partition, which may impact read performance")
     }
-    partitions
+    withComplement(partitions.toSeq).toArray
+  }
+
+  /**
+   * Appends one input partition covering every partition absent from `parts`. The partition listing
+   * comes from `system.parts`, which is only eventually consistent on ClickHouse Cloud: a listing
+   * that misses a partition would otherwise prune it away and silently return incomplete results.
+   * The complement makes the task predicates exhaustive, so a stale listing costs read parallelism
+   * instead of rows.
+   *
+   * Skipped unless splitting by `_partition_id` (the partition-value predicates have known bugs and
+   * ill-defined NOT IN semantics), and skipped when the listing collapsed to [[NoPartitionSpec]],
+   * which already scans the whole table.
+   */
+  private def withComplement(parts: Seq[ClickHouseInputPartition]): Seq[ClickHouseInputPartition] = {
+    val partitionIds = parts.map(_.partition.partition_id)
+    if (!scanJob.readOptions.splitByPartitionId || parts.isEmpty || partitionIds.exists(_.isEmpty)) {
+      parts
+    } else {
+      parts :+ parts.head.copy(partition = NoPartitionSpec, complementOf = partitionIds)
+    }
   }
 
   override def toBatch: Batch = this

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -38,6 +38,15 @@ abstract class ClickHouseReader[Record](
   val readDistributedConvertLocal: Boolean = conf.getConf(READ_DISTRIBUTED_CONVERT_LOCAL)
   private val readSettings: Option[String] = conf.getConf(READ_SETTINGS)
 
+  /**
+   * A complement partition matches nothing whenever the partition listing was complete. That reads
+   * as zero rows normally and for a GROUP BY aggregation, but a pushed-down aggregation without
+   * GROUP BY still returns one row holding the aggregate of the empty set (`min` of no rows is 0),
+   * which would corrupt the value Spark combines across partitions. Drop that row.
+   */
+  private val emptyAggregateGuard: String =
+    if (part.complementOf.nonEmpty && scanJob.groupByClause.isDefined) "HAVING count() > 0" else ""
+
   val database: String = part.table.database
   val table: String = part.table.name
 //  val codec: ClickHouseCompression = scanJob.readOptions.compressionCodec
@@ -60,6 +69,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |$emptyAggregateGuard
        |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
@@ -29,7 +29,10 @@ case class ClickHouseInputPartition(
   partition: PartitionSpec,
   filterByPartitionId: Boolean,
   candidateNodes: Nodes, // try to use them only when preferredNode unavailable
-  preferredNode: Option[NodeSpec] = None // TODO assigned by ScanBuilder in Spark Driver side
+  preferredNode: Option[NodeSpec] = None, // TODO assigned by ScanBuilder in Spark Driver side
+  // When non-empty this input partition covers every partition *absent* from these ids, so that an
+  // incomplete partition listing can not silently drop rows. See ClickHouseBatchScan#withComplement.
+  complementOf: Seq[String] = Nil
 ) extends InputPartition {
 
   override def preferredLocations(): Array[String] = preferredNode match {
@@ -37,7 +40,9 @@ case class ClickHouseInputPartition(
     case None => candidateNodes.nodes.map(_.host)
   }
 
-  def partFilterExpr: String = partition match {
+  def partFilterExpr: String = if (complementOf.nonEmpty) {
+    complementOf.map(id => s"'$id'").mkString("_partition_id NOT IN (", ", ", ")")
+  } else partition match {
     case NoPartitionSpec => "1=1"
     case PartitionSpec(_, partitionId, _, _) if filterByPartitionId =>
       s"_partition_id = '$partitionId'"

--- a/spark-3.3/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -15,7 +15,15 @@
 package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
+import com.clickhouse.spark.ClickHouseTable
+import com.clickhouse.spark.spec.{
+  DistributedEngineSpec,
+  MergeTreeEngineSpec,
+  NoPartitionSpec,
+  NodeSpec,
+  PartitionSpec,
+  TableSpec
+}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -50,6 +58,20 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     // NoPartitionSpec already reads everything, so a complement would double-read the table
     assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
     assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  test("table identity ignores volatile runtime statistics") {
+    def table(rows: Option[Long]): ClickHouseTable = ClickHouseTable(
+      node = NodeSpec("127.0.0.1"),
+      cluster = None,
+      tz = ZoneId.of("UTC"),
+      spec = tableSpec().copy(total_rows = rows, total_bytes = rows, lifetime_rows = rows),
+      engineSpec = MergeTreeEngineSpec(engine_clause = "MergeTree")
+    )
+    // two catalog loads of the same table must stay equal while data commits, or plan reuse breaks
+    assert(table(Some(0L)) === table(Some(2L)))
+    assert(table(Some(0L)).hashCode === table(Some(2L)).hashCode)
+    assert(table(None) === table(Some(2L)))
   }
 
   private def inputPartition(

--- a/spark-3.3/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -15,7 +15,7 @@
 package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NodeSpec, TableSpec}
+import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -35,6 +35,58 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     assert(warnings.exists(_.contains("Reading db.dist as a single partition")))
   }
 
+  test("the complement input partition covers every partition absent from the listing") {
+    val complement = inputPartition(NoPartitionSpec, complementOf = Seq("20220411", "20220412"))
+    assert(complement.partFilterExpr === "_partition_id NOT IN ('20220411', '20220412')")
+  }
+
+  test("a listed input partition still filters by its own partition id") {
+    val listed = inputPartition(PartitionSpec("2022-04-11", "20220411", 1, 1))
+    assert(listed.partFilterExpr === "_partition_id = '20220411'")
+  }
+
+  test("no complement is planned when the listing collapsed to a whole-table scan") {
+    val scan = new ClickHouseBatchScan(scanJob())
+    // NoPartitionSpec already reads everything, so a complement would double-read the table
+    assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
+    assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  private def inputPartition(
+    partition: PartitionSpec,
+    complementOf: Seq[String] = Nil
+  ): ClickHouseInputPartition = ClickHouseInputPartition(
+    table = tableSpec(),
+    partition = partition,
+    filterByPartitionId = true,
+    candidateNodes = NodeSpec("127.0.0.1"),
+    complementOf = complementOf
+  )
+
+  private def tableSpec(): TableSpec = TableSpec(
+    database = "db",
+    name = "dist",
+    uuid = "",
+    engine = "Distributed",
+    is_temporary = false,
+    data_paths = Nil,
+    metadata_path = "",
+    metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
+    dependencies_database = Nil,
+    dependencies_table = Nil,
+    create_table_query = "",
+    engine_full = "Distributed('single', 'db', 'local')",
+    partition_key = "",
+    sorting_key = "",
+    primary_key = "",
+    sampling_key = "",
+    storage_policy = "",
+    total_rows = None,
+    total_bytes = None,
+    lifetime_rows = None,
+    lifetime_bytes = None
+  )
+
   // a Distributed table scan without convertDistributedToLocal plans exactly one partition without any I/O
   private def scanJob(): ScanJobDescription = {
     val readOptions = new java.util.HashMap[String, String]()
@@ -43,29 +95,7 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     ScanJobDescription(
       node = NodeSpec("127.0.0.1"),
       tz = ZoneId.of("UTC"),
-      tableSpec = TableSpec(
-        database = "db",
-        name = "dist",
-        uuid = "",
-        engine = "Distributed",
-        is_temporary = false,
-        data_paths = Nil,
-        metadata_path = "",
-        metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
-        dependencies_database = Nil,
-        dependencies_table = Nil,
-        create_table_query = "",
-        engine_full = "Distributed('single', 'db', 'local')",
-        partition_key = "",
-        sorting_key = "",
-        primary_key = "",
-        sampling_key = "",
-        storage_policy = "",
-        total_rows = None,
-        total_bytes = None,
-        lifetime_rows = None,
-        lifetime_bytes = None
-      ),
+      tableSpec = tableSpec(),
       tableEngineSpec = DistributedEngineSpec(
         engine_clause = "Distributed('single', 'db', 'local')",
         cluster = "single",

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -85,6 +85,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -63,6 +63,33 @@ case class ClickHouseTable(
     with SQLHelper
     with Logging {
 
+  /**
+   * Runtime statistics are not part of a table's identity. `total_rows`, `total_bytes` and the
+   * `lifetime_*` counters move as data commits, so letting them into equality makes two catalog
+   * loads of the same table unequal. Spark compares plans to find cached data, and a
+   * DataSourceV2Relation carries this Table, so a shifting identity silently defeats plan reuse
+   * (CACHE TABLE, reused exchanges, self-join detection). They stay in `properties()`; only
+   * equality ignores them.
+   */
+  private def identityKey =
+    (
+      node,
+      cluster,
+      tz,
+      spec.copy(total_rows = None, total_bytes = None, lifetime_rows = None, lifetime_bytes = None),
+      engineSpec,
+      // `functionRegistry` is one instance per catalog, already implied by node/cluster;
+      // `functionCatalogUsable` genuinely separates catalog tables from format("clickhouse") ones
+      functionCatalogUsable
+    )
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ClickHouseTable => identityKey == that.identityKey
+    case _ => false
+  }
+
+  override def hashCode(): Int = identityKey.hashCode()
+
   def database: String = spec.database
 
   def table: String = spec.name

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -233,7 +233,27 @@ class ClickHouseBatchScan(scanJob: ScanJobDescription) extends Scan with Batch
     if (partitions.length == 1) {
       log.warn(s"Reading $database.$table as a single partition, which may impact read performance")
     }
-    partitions
+    withComplement(partitions.toSeq).toArray
+  }
+
+  /**
+   * Appends one input partition covering every partition absent from `parts`. The partition listing
+   * comes from `system.parts`, which is only eventually consistent on ClickHouse Cloud: a listing
+   * that misses a partition would otherwise prune it away and silently return incomplete results.
+   * The complement makes the task predicates exhaustive, so a stale listing costs read parallelism
+   * instead of rows.
+   *
+   * Skipped unless splitting by `_partition_id` (the partition-value predicates have known bugs and
+   * ill-defined NOT IN semantics), and skipped when the listing collapsed to [[NoPartitionSpec]],
+   * which already scans the whole table.
+   */
+  private def withComplement(parts: Seq[ClickHouseInputPartition]): Seq[ClickHouseInputPartition] = {
+    val partitionIds = parts.map(_.partition.partition_id)
+    if (!scanJob.readOptions.splitByPartitionId || parts.isEmpty || partitionIds.exists(_.isEmpty)) {
+      parts
+    } else {
+      parts :+ parts.head.copy(partition = NoPartitionSpec, complementOf = partitionIds)
+    }
   }
 
   override def toBatch: Batch = this

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -38,6 +38,15 @@ abstract class ClickHouseReader[Record](
   val readDistributedConvertLocal: Boolean = conf.getConf(READ_DISTRIBUTED_CONVERT_LOCAL)
   private val readSettings: Option[String] = conf.getConf(READ_SETTINGS)
 
+  /**
+   * A complement partition matches nothing whenever the partition listing was complete. That reads
+   * as zero rows normally and for a GROUP BY aggregation, but a pushed-down aggregation without
+   * GROUP BY still returns one row holding the aggregate of the empty set (`min` of no rows is 0),
+   * which would corrupt the value Spark combines across partitions. Drop that row.
+   */
+  private val emptyAggregateGuard: String =
+    if (part.complementOf.nonEmpty && scanJob.groupByClause.isDefined) "HAVING count() > 0" else ""
+
   val database: String = part.table.database
   val table: String = part.table.name
 //  val codec: ClickHouseCompression = scanJob.readOptions.compressionCodec
@@ -60,6 +69,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |$emptyAggregateGuard
        |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
@@ -29,7 +29,10 @@ case class ClickHouseInputPartition(
   partition: PartitionSpec,
   filterByPartitionId: Boolean,
   candidateNodes: Nodes, // try to use them only when preferredNode unavailable
-  preferredNode: Option[NodeSpec] = None // TODO assigned by ScanBuilder in Spark Driver side
+  preferredNode: Option[NodeSpec] = None, // TODO assigned by ScanBuilder in Spark Driver side
+  // When non-empty this input partition covers every partition *absent* from these ids, so that an
+  // incomplete partition listing can not silently drop rows. See ClickHouseBatchScan#withComplement.
+  complementOf: Seq[String] = Nil
 ) extends InputPartition {
 
   override def preferredLocations(): Array[String] = preferredNode match {
@@ -37,7 +40,9 @@ case class ClickHouseInputPartition(
     case None => candidateNodes.nodes.map(_.host)
   }
 
-  def partFilterExpr: String = partition match {
+  def partFilterExpr: String = if (complementOf.nonEmpty) {
+    complementOf.map(id => s"'$id'").mkString("_partition_id NOT IN (", ", ", ")")
+  } else partition match {
     case NoPartitionSpec => "1=1"
     case PartitionSpec(_, partitionId, _, _) if filterByPartitionId =>
       s"_partition_id = '$partitionId'"

--- a/spark-3.4/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,15 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
+import com.clickhouse.spark.ClickHouseTable
+import com.clickhouse.spark.spec.{
+  DistributedEngineSpec,
+  MergeTreeEngineSpec,
+  NoPartitionSpec,
+  NodeSpec,
+  PartitionSpec,
+  TableSpec
+}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -51,6 +59,21 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     // NoPartitionSpec already reads everything, so a complement would double-read the table
     assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
     assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  test("table identity ignores volatile runtime statistics") {
+    def table(rows: Option[Long]): ClickHouseTable = ClickHouseTable(
+      node = NodeSpec("127.0.0.1"),
+      cluster = None,
+      tz = ZoneId.of("UTC"),
+      spec = tableSpec().copy(total_rows = rows, total_bytes = rows, lifetime_rows = rows),
+      engineSpec = MergeTreeEngineSpec(engine_clause = "MergeTree"),
+      functionRegistry = StaticFunctionRegistry
+    )
+    // two catalog loads of the same table must stay equal while data commits, or plan reuse breaks
+    assert(table(Some(0L)) === table(Some(2L)))
+    assert(table(Some(0L)).hashCode === table(Some(2L)).hashCode)
+    assert(table(None) === table(Some(2L)))
   }
 
   private def inputPartition(

--- a/spark-3.4/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,7 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NodeSpec, TableSpec}
+import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -36,6 +36,58 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     assert(warnings.exists(_.contains("Reading db.dist as a single partition")))
   }
 
+  test("the complement input partition covers every partition absent from the listing") {
+    val complement = inputPartition(NoPartitionSpec, complementOf = Seq("20220411", "20220412"))
+    assert(complement.partFilterExpr === "_partition_id NOT IN ('20220411', '20220412')")
+  }
+
+  test("a listed input partition still filters by its own partition id") {
+    val listed = inputPartition(PartitionSpec("2022-04-11", "20220411", 1, 1))
+    assert(listed.partFilterExpr === "_partition_id = '20220411'")
+  }
+
+  test("no complement is planned when the listing collapsed to a whole-table scan") {
+    val scan = new ClickHouseBatchScan(scanJob())
+    // NoPartitionSpec already reads everything, so a complement would double-read the table
+    assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
+    assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  private def inputPartition(
+    partition: PartitionSpec,
+    complementOf: Seq[String] = Nil
+  ): ClickHouseInputPartition = ClickHouseInputPartition(
+    table = tableSpec(),
+    partition = partition,
+    filterByPartitionId = true,
+    candidateNodes = NodeSpec("127.0.0.1"),
+    complementOf = complementOf
+  )
+
+  private def tableSpec(): TableSpec = TableSpec(
+    database = "db",
+    name = "dist",
+    uuid = "",
+    engine = "Distributed",
+    is_temporary = false,
+    data_paths = Nil,
+    metadata_path = "",
+    metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
+    dependencies_database = Nil,
+    dependencies_table = Nil,
+    create_table_query = "",
+    engine_full = "Distributed('single', 'db', 'local')",
+    partition_key = "",
+    sorting_key = "",
+    primary_key = "",
+    sampling_key = "",
+    storage_policy = "",
+    total_rows = None,
+    total_bytes = None,
+    lifetime_rows = None,
+    lifetime_bytes = None
+  )
+
   // a Distributed table scan without convertDistributedToLocal plans exactly one partition without any I/O
   private def scanJob(): ScanJobDescription = {
     val readOptions = new java.util.HashMap[String, String]()
@@ -44,29 +96,7 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     ScanJobDescription(
       node = NodeSpec("127.0.0.1"),
       tz = ZoneId.of("UTC"),
-      tableSpec = TableSpec(
-        database = "db",
-        name = "dist",
-        uuid = "",
-        engine = "Distributed",
-        is_temporary = false,
-        data_paths = Nil,
-        metadata_path = "",
-        metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
-        dependencies_database = Nil,
-        dependencies_table = Nil,
-        create_table_query = "",
-        engine_full = "Distributed('single', 'db', 'local')",
-        partition_key = "",
-        sorting_key = "",
-        primary_key = "",
-        sampling_key = "",
-        storage_policy = "",
-        total_rows = None,
-        total_bytes = None,
-        lifetime_rows = None,
-        lifetime_bytes = None
-      ),
+      tableSpec = tableSpec(),
       tableEngineSpec = DistributedEngineSpec(
         engine_clause = "Distributed('single', 'db', 'local')",
         cluster = "single",

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -86,6 +86,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -73,6 +73,33 @@ case class ClickHouseTable(
     with SQLHelper
     with Logging {
 
+  /**
+   * Runtime statistics are not part of a table's identity. `total_rows`, `total_bytes` and the
+   * `lifetime_*` counters move as data commits, so letting them into equality makes two catalog
+   * loads of the same table unequal. Spark compares plans to find cached data, and a
+   * DataSourceV2Relation carries this Table, so a shifting identity silently defeats plan reuse
+   * (CACHE TABLE, reused exchanges, self-join detection). They stay in `properties()`; only
+   * equality ignores them.
+   */
+  private def identityKey =
+    (
+      node,
+      cluster,
+      tz,
+      spec.copy(total_rows = None, total_bytes = None, lifetime_rows = None, lifetime_bytes = None),
+      engineSpec,
+      // `functionRegistry` is one instance per catalog, already implied by node/cluster;
+      // `functionCatalogUsable` genuinely separates catalog tables from format("clickhouse") ones
+      functionCatalogUsable
+    )
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ClickHouseTable => identityKey == that.identityKey
+    case _ => false
+  }
+
+  override def hashCode(): Int = identityKey.hashCode()
+
   def database: String = spec.database
 
   def table: String = spec.name

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -235,7 +235,27 @@ class ClickHouseBatchScan(scanJob: ScanJobDescription) extends Scan with Batch
     if (partitions.length == 1) {
       log.warn(s"Reading $database.$table as a single partition, which may impact read performance")
     }
-    partitions
+    withComplement(partitions.toSeq).toArray
+  }
+
+  /**
+   * Appends one input partition covering every partition absent from `parts`. The partition listing
+   * comes from `system.parts`, which is only eventually consistent on ClickHouse Cloud: a listing
+   * that misses a partition would otherwise prune it away and silently return incomplete results.
+   * The complement makes the task predicates exhaustive, so a stale listing costs read parallelism
+   * instead of rows.
+   *
+   * Skipped unless splitting by `_partition_id` (the partition-value predicates have known bugs and
+   * ill-defined NOT IN semantics), and skipped when the listing collapsed to [[NoPartitionSpec]],
+   * which already scans the whole table.
+   */
+  private def withComplement(parts: Seq[ClickHouseInputPartition]): Seq[ClickHouseInputPartition] = {
+    val partitionIds = parts.map(_.partition.partition_id)
+    if (!scanJob.readOptions.splitByPartitionId || parts.isEmpty || partitionIds.exists(_.isEmpty)) {
+      parts
+    } else {
+      parts :+ parts.head.copy(partition = NoPartitionSpec, complementOf = partitionIds)
+    }
   }
 
   override def toBatch: Batch = this

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -38,6 +38,15 @@ abstract class ClickHouseReader[Record](
   val readDistributedConvertLocal: Boolean = conf.getConf(READ_DISTRIBUTED_CONVERT_LOCAL)
   private val readSettings: Option[String] = conf.getConf(READ_SETTINGS)
 
+  /**
+   * A complement partition matches nothing whenever the partition listing was complete. That reads
+   * as zero rows normally and for a GROUP BY aggregation, but a pushed-down aggregation without
+   * GROUP BY still returns one row holding the aggregate of the empty set (`min` of no rows is 0),
+   * which would corrupt the value Spark combines across partitions. Drop that row.
+   */
+  private val emptyAggregateGuard: String =
+    if (part.complementOf.nonEmpty && scanJob.groupByClause.isDefined) "HAVING count() > 0" else ""
+
   val database: String = part.table.database
   val table: String = part.table.name
   val readSchema: StructType = scanJob.readSchema
@@ -59,6 +68,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |$emptyAggregateGuard
        |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
@@ -30,7 +30,10 @@ case class ClickHouseInputPartition(
   partition: PartitionSpec,
   filterByPartitionId: Boolean,
   candidateNodes: Nodes, // try to use them only when preferredNode unavailable
-  preferredNode: Option[NodeSpec] = None // TODO assigned by ScanBuilder in Spark Driver side
+  preferredNode: Option[NodeSpec] = None, // TODO assigned by ScanBuilder in Spark Driver side
+  // When non-empty this input partition covers every partition *absent* from these ids, so that an
+  // incomplete partition listing can not silently drop rows. See ClickHouseBatchScan#withComplement.
+  complementOf: Seq[String] = Nil
 ) extends InputPartition {
 
   override def preferredLocations(): Array[String] = preferredNode match {
@@ -38,7 +41,9 @@ case class ClickHouseInputPartition(
     case None => candidateNodes.nodes.map(_.host)
   }
 
-  def partFilterExpr: String = partition match {
+  def partFilterExpr: String = if (complementOf.nonEmpty) {
+    complementOf.map(id => s"'$id'").mkString("_partition_id NOT IN (", ", ", ")")
+  } else partition match {
     case NoPartitionSpec => "1=1"
     case PartitionSpec(_, partitionId, _, _) if filterByPartitionId =>
       s"_partition_id = '$partitionId'"

--- a/spark-3.5/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,15 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
+import com.clickhouse.spark.ClickHouseTable
+import com.clickhouse.spark.spec.{
+  DistributedEngineSpec,
+  MergeTreeEngineSpec,
+  NoPartitionSpec,
+  NodeSpec,
+  PartitionSpec,
+  TableSpec
+}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -51,6 +59,21 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     // NoPartitionSpec already reads everything, so a complement would double-read the table
     assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
     assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  test("table identity ignores volatile runtime statistics") {
+    def table(rows: Option[Long]): ClickHouseTable = ClickHouseTable(
+      node = NodeSpec("127.0.0.1"),
+      cluster = None,
+      tz = ZoneId.of("UTC"),
+      spec = tableSpec().copy(total_rows = rows, total_bytes = rows, lifetime_rows = rows),
+      engineSpec = MergeTreeEngineSpec(engine_clause = "MergeTree"),
+      functionRegistry = StaticFunctionRegistry
+    )
+    // two catalog loads of the same table must stay equal while data commits, or plan reuse breaks
+    assert(table(Some(0L)) === table(Some(2L)))
+    assert(table(Some(0L)).hashCode === table(Some(2L)).hashCode)
+    assert(table(None) === table(Some(2L)))
   }
 
   private def inputPartition(

--- a/spark-3.5/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,7 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NodeSpec, TableSpec}
+import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -36,6 +36,58 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     assert(warnings.exists(_.contains("Reading db.dist as a single partition")))
   }
 
+  test("the complement input partition covers every partition absent from the listing") {
+    val complement = inputPartition(NoPartitionSpec, complementOf = Seq("20220411", "20220412"))
+    assert(complement.partFilterExpr === "_partition_id NOT IN ('20220411', '20220412')")
+  }
+
+  test("a listed input partition still filters by its own partition id") {
+    val listed = inputPartition(PartitionSpec("2022-04-11", "20220411", 1, 1))
+    assert(listed.partFilterExpr === "_partition_id = '20220411'")
+  }
+
+  test("no complement is planned when the listing collapsed to a whole-table scan") {
+    val scan = new ClickHouseBatchScan(scanJob())
+    // NoPartitionSpec already reads everything, so a complement would double-read the table
+    assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
+    assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  private def inputPartition(
+    partition: PartitionSpec,
+    complementOf: Seq[String] = Nil
+  ): ClickHouseInputPartition = ClickHouseInputPartition(
+    table = tableSpec(),
+    partition = partition,
+    filterByPartitionId = true,
+    candidateNodes = NodeSpec("127.0.0.1"),
+    complementOf = complementOf
+  )
+
+  private def tableSpec(): TableSpec = TableSpec(
+    database = "db",
+    name = "dist",
+    uuid = "",
+    engine = "Distributed",
+    is_temporary = false,
+    data_paths = Nil,
+    metadata_path = "",
+    metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
+    dependencies_database = Nil,
+    dependencies_table = Nil,
+    create_table_query = "",
+    engine_full = "Distributed('single', 'db', 'local')",
+    partition_key = "",
+    sorting_key = "",
+    primary_key = "",
+    sampling_key = "",
+    storage_policy = "",
+    total_rows = None,
+    total_bytes = None,
+    lifetime_rows = None,
+    lifetime_bytes = None
+  )
+
   // a Distributed table scan without convertDistributedToLocal plans exactly one partition without any I/O
   private def scanJob(): ScanJobDescription = {
     val readOptions = new java.util.HashMap[String, String]()
@@ -44,29 +96,7 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     ScanJobDescription(
       node = NodeSpec("127.0.0.1"),
       tz = ZoneId.of("UTC"),
-      tableSpec = TableSpec(
-        database = "db",
-        name = "dist",
-        uuid = "",
-        engine = "Distributed",
-        is_temporary = false,
-        data_paths = Nil,
-        metadata_path = "",
-        metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
-        dependencies_database = Nil,
-        dependencies_table = Nil,
-        create_table_query = "",
-        engine_full = "Distributed('single', 'db', 'local')",
-        partition_key = "",
-        sorting_key = "",
-        primary_key = "",
-        sampling_key = "",
-        storage_policy = "",
-        total_rows = None,
-        total_bytes = None,
-        lifetime_rows = None,
-        lifetime_bytes = None
-      ),
+      tableSpec = tableSpec(),
       tableEngineSpec = DistributedEngineSpec(
         engine_clause = "Distributed('single', 'db', 'local')",
         cluster = "single",

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -85,6 +85,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -73,6 +73,33 @@ case class ClickHouseTable(
     with SQLHelper
     with Logging {
 
+  /**
+   * Runtime statistics are not part of a table's identity. `total_rows`, `total_bytes` and the
+   * `lifetime_*` counters move as data commits, so letting them into equality makes two catalog
+   * loads of the same table unequal. Spark compares plans to find cached data, and a
+   * DataSourceV2Relation carries this Table, so a shifting identity silently defeats plan reuse
+   * (CACHE TABLE, reused exchanges, self-join detection). They stay in `properties()`; only
+   * equality ignores them.
+   */
+  private def identityKey =
+    (
+      node,
+      cluster,
+      tz,
+      spec.copy(total_rows = None, total_bytes = None, lifetime_rows = None, lifetime_bytes = None),
+      engineSpec,
+      // `functionRegistry` is one instance per catalog, already implied by node/cluster;
+      // `functionCatalogUsable` genuinely separates catalog tables from format("clickhouse") ones
+      functionCatalogUsable
+    )
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ClickHouseTable => identityKey == that.identityKey
+    case _ => false
+  }
+
+  override def hashCode(): Int = identityKey.hashCode()
+
   def database: String = spec.database
 
   def table: String = spec.name

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -235,7 +235,27 @@ class ClickHouseBatchScan(scanJob: ScanJobDescription) extends Scan with Batch
     if (partitions.length == 1) {
       log.warn(s"Reading $database.$table as a single partition, which may impact read performance")
     }
-    partitions
+    withComplement(partitions.toSeq).toArray
+  }
+
+  /**
+   * Appends one input partition covering every partition absent from `parts`. The partition listing
+   * comes from `system.parts`, which is only eventually consistent on ClickHouse Cloud: a listing
+   * that misses a partition would otherwise prune it away and silently return incomplete results.
+   * The complement makes the task predicates exhaustive, so a stale listing costs read parallelism
+   * instead of rows.
+   *
+   * Skipped unless splitting by `_partition_id` (the partition-value predicates have known bugs and
+   * ill-defined NOT IN semantics), and skipped when the listing collapsed to [[NoPartitionSpec]],
+   * which already scans the whole table.
+   */
+  private def withComplement(parts: Seq[ClickHouseInputPartition]): Seq[ClickHouseInputPartition] = {
+    val partitionIds = parts.map(_.partition.partition_id)
+    if (!scanJob.readOptions.splitByPartitionId || parts.isEmpty || partitionIds.exists(_.isEmpty)) {
+      parts
+    } else {
+      parts :+ parts.head.copy(partition = NoPartitionSpec, complementOf = partitionIds)
+    }
   }
 
   override def toBatch: Batch = this

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -38,6 +38,15 @@ abstract class ClickHouseReader[Record](
   val readDistributedConvertLocal: Boolean = conf.getConf(READ_DISTRIBUTED_CONVERT_LOCAL)
   private val readSettings: Option[String] = conf.getConf(READ_SETTINGS)
 
+  /**
+   * A complement partition matches nothing whenever the partition listing was complete. That reads
+   * as zero rows normally and for a GROUP BY aggregation, but a pushed-down aggregation without
+   * GROUP BY still returns one row holding the aggregate of the empty set (`min` of no rows is 0),
+   * which would corrupt the value Spark combines across partitions. Drop that row.
+   */
+  private val emptyAggregateGuard: String =
+    if (part.complementOf.nonEmpty && scanJob.groupByClause.isDefined) "HAVING count() > 0" else ""
+
   val database: String = part.table.database
   val table: String = part.table.name
   val readSchema: StructType = scanJob.readSchema
@@ -59,6 +68,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |$emptyAggregateGuard
        |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/InputPartitions.scala
@@ -30,7 +30,10 @@ case class ClickHouseInputPartition(
   partition: PartitionSpec,
   filterByPartitionId: Boolean,
   candidateNodes: Nodes, // try to use them only when preferredNode unavailable
-  preferredNode: Option[NodeSpec] = None // TODO assigned by ScanBuilder in Spark Driver side
+  preferredNode: Option[NodeSpec] = None, // TODO assigned by ScanBuilder in Spark Driver side
+  // When non-empty this input partition covers every partition *absent* from these ids, so that an
+  // incomplete partition listing can not silently drop rows. See ClickHouseBatchScan#withComplement.
+  complementOf: Seq[String] = Nil
 ) extends InputPartition {
 
   override def preferredLocations(): Array[String] = preferredNode match {
@@ -38,7 +41,9 @@ case class ClickHouseInputPartition(
     case None => candidateNodes.nodes.map(_.host)
   }
 
-  def partFilterExpr: String = partition match {
+  def partFilterExpr: String = if (complementOf.nonEmpty) {
+    complementOf.map(id => s"'$id'").mkString("_partition_id NOT IN (", ", ", ")")
+  } else partition match {
     case NoPartitionSpec => "1=1"
     case PartitionSpec(_, partitionId, _, _) if filterByPartitionId =>
       s"_partition_id = '$partitionId'"

--- a/spark-4.0/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,15 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
+import com.clickhouse.spark.ClickHouseTable
+import com.clickhouse.spark.spec.{
+  DistributedEngineSpec,
+  MergeTreeEngineSpec,
+  NoPartitionSpec,
+  NodeSpec,
+  PartitionSpec,
+  TableSpec
+}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -51,6 +59,21 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     // NoPartitionSpec already reads everything, so a complement would double-read the table
     assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
     assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  test("table identity ignores volatile runtime statistics") {
+    def table(rows: Option[Long]): ClickHouseTable = ClickHouseTable(
+      node = NodeSpec("127.0.0.1"),
+      cluster = None,
+      tz = ZoneId.of("UTC"),
+      spec = tableSpec().copy(total_rows = rows, total_bytes = rows, lifetime_rows = rows),
+      engineSpec = MergeTreeEngineSpec(engine_clause = "MergeTree"),
+      functionRegistry = StaticFunctionRegistry
+    )
+    // two catalog loads of the same table must stay equal while data commits, or plan reuse breaks
+    assert(table(Some(0L)) === table(Some(2L)))
+    assert(table(Some(0L)).hashCode === table(Some(2L)).hashCode)
+    assert(table(None) === table(Some(2L)))
   }
 
   private def inputPartition(

--- a/spark-4.0/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/com/clickhouse/spark/read/ClickHouseBatchScanSuite.scala
@@ -16,7 +16,7 @@ package com.clickhouse.spark.read
 
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.func.StaticFunctionRegistry
-import com.clickhouse.spark.spec.{DistributedEngineSpec, NodeSpec, TableSpec}
+import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, NodeSpec, PartitionSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{
   READ_DISTRIBUTED_CONVERT_LOCAL,
   READ_DISTRIBUTED_USE_CLUSTER_NODES
@@ -36,6 +36,58 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     assert(warnings.exists(_.contains("Reading db.dist as a single partition")))
   }
 
+  test("the complement input partition covers every partition absent from the listing") {
+    val complement = inputPartition(NoPartitionSpec, complementOf = Seq("20220411", "20220412"))
+    assert(complement.partFilterExpr === "_partition_id NOT IN ('20220411', '20220412')")
+  }
+
+  test("a listed input partition still filters by its own partition id") {
+    val listed = inputPartition(PartitionSpec("2022-04-11", "20220411", 1, 1))
+    assert(listed.partFilterExpr === "_partition_id = '20220411'")
+  }
+
+  test("no complement is planned when the listing collapsed to a whole-table scan") {
+    val scan = new ClickHouseBatchScan(scanJob())
+    // NoPartitionSpec already reads everything, so a complement would double-read the table
+    assert(scan.inputPartitions.forall(_.complementOf.isEmpty))
+    assert(scan.inputPartitions.map(_.partFilterExpr).toSeq === Seq("1=1"))
+  }
+
+  private def inputPartition(
+    partition: PartitionSpec,
+    complementOf: Seq[String] = Nil
+  ): ClickHouseInputPartition = ClickHouseInputPartition(
+    table = tableSpec(),
+    partition = partition,
+    filterByPartitionId = true,
+    candidateNodes = NodeSpec("127.0.0.1"),
+    complementOf = complementOf
+  )
+
+  private def tableSpec(): TableSpec = TableSpec(
+    database = "db",
+    name = "dist",
+    uuid = "",
+    engine = "Distributed",
+    is_temporary = false,
+    data_paths = Nil,
+    metadata_path = "",
+    metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
+    dependencies_database = Nil,
+    dependencies_table = Nil,
+    create_table_query = "",
+    engine_full = "Distributed('single', 'db', 'local')",
+    partition_key = "",
+    sorting_key = "",
+    primary_key = "",
+    sampling_key = "",
+    storage_policy = "",
+    total_rows = None,
+    total_bytes = None,
+    lifetime_rows = None,
+    lifetime_bytes = None
+  )
+
   // a Distributed table scan without convertDistributedToLocal plans exactly one partition without any I/O
   private def scanJob(): ScanJobDescription = {
     val readOptions = new java.util.HashMap[String, String]()
@@ -44,29 +96,7 @@ class ClickHouseBatchScanSuite extends AnyFunSuite with Log4j2CaptureHelper {
     ScanJobDescription(
       node = NodeSpec("127.0.0.1"),
       tz = ZoneId.of("UTC"),
-      tableSpec = TableSpec(
-        database = "db",
-        name = "dist",
-        uuid = "",
-        engine = "Distributed",
-        is_temporary = false,
-        data_paths = Nil,
-        metadata_path = "",
-        metadata_modification_time = LocalDateTime.of(2026, 1, 1, 0, 0),
-        dependencies_database = Nil,
-        dependencies_table = Nil,
-        create_table_query = "",
-        engine_full = "Distributed('single', 'db', 'local')",
-        partition_key = "",
-        sorting_key = "",
-        primary_key = "",
-        sampling_key = "",
-        storage_policy = "",
-        total_rows = None,
-        total_bytes = None,
-        lifetime_rows = None,
-        lifetime_bytes = None
-      ),
+      tableSpec = tableSpec(),
       tableEngineSpec = DistributedEngineSpec(
         engine_clause = "Distributed('single', 'db', 'local')",
         cluster = "single",


### PR DESCRIPTION
The nightly ClickHouse Cloud job failed 26 of the last 30 runs — all 13 matrix jobs, on a different random set of tests each night. Two independent causes, both from the CI service being one endpoint backed by three replicas whose views of the data are only eventually consistent.

**1. Reads could land on a replica that hadn't caught up** and silently return an empty table (`Array() had length 0`, `Results do not match`). Confirmed in `system.query_log`: for the failing `decode IPv4` test the insert landed on `svocwnp`, reads on `svocwnp`/`nqojoyp` returned 3 rows, the read on `jzgtt5a` returned 0.

Fix: `select_sequential_consistency=1` for Cloud reads, via `spark.clickhouse.read.settings` — a session-level conf applied to the scan SQL, so it covers both the catalog `spark.sql(...)` path and `spark.read.format("clickhouse")` (the latter sets no `clickhouse_setting_*` options of its own). Gated on `isCloud` since only replicated engines honour it. Measured over 100 iterations of create → async insert → immediate read: **6/100 stale by default, 0/100 with the setting**. This took the run from 13/13 jobs failing to 12/13 passing.

**2. A stale partition listing silently dropped rows.** A scan plans one task per partition from `queryPartitionSpec` (`_partition_id = '<id>'`), so the scan result is the union of those predicates — correctness depends on the listing being complete. It reads `system.parts`, which is eventually consistent. In CI two listings of the same table one second apart on the same replica returned 3 and 4 partitions; the 3-partition plan never queried partition `20220422` and returned 3 rows instead of 4, with no error. Three tests failed this way (`clickhouse partition (date type)`, `clickhouse multi part columns`, `clickhouse metadata column`).

`select_sequential_consistency` cannot fix this — the query for the missing partition is never issued, because the planner never learned it existed.

Fix: plan one additional task filtering `_partition_id NOT IN (<listed ids>)`. The predicates are then exhaustive by construction — every row matches either a listed partition or the complement, with no overlap — so an incomplete listing costs read parallelism instead of rows. Skipped when the listing collapsed to `NoPartitionSpec` (already a whole-table scan, would otherwise double-read) and when not splitting by `_partition_id`.

Note that (2) is a data-correctness bug for any Cloud user reading a partitioned table, not only for the tests.
