### PR TITLE
test(cloud): stop the Cloud suites racing eventual consistency

### DIFF
--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,9 +19,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -31,11 +29,6 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
-  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -459,7 +459,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
       // Tag the query so we can pull it from system.query_log by log_comment.
       val topNLogTag = java.util.UUID.randomUUID().toString
-      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith(s"log_comment='$topNLogTag'")) {
         checkAnswer(
           spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
           Seq(Row(40L), Row(30L))

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,9 +17,7 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -30,11 +28,6 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
-  // caught up with a recent write. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.clickhouse.SparkTest
 import org.apache.spark.sql.functions.month
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
 import java.util.UUID
 import scala.util.{Failure, Success, Try}
@@ -36,6 +38,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
   }
 
   protected def useSuiteLevelDatabase: Boolean = isCloud
+
+  /**
+   * Cloud's multi-replica compute can serve a read from a replica whose part or mutation cache has
+   * not yet caught up with a recent write or DELETE. Retries `body` until reads converge, and runs
+   * it once unchanged when not on Cloud.
+   */
+  protected def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -37,6 +37,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     s"test_db_${timestamp}_${uuidPrefix}"
   }
 
+  protected val READ_SETTINGS_KEY = "spark.clickhouse.read.settings"
+
   protected def useSuiteLevelDatabase: Boolean = isCloud
 
   /**
@@ -102,8 +104,20 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
    * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
    * insert, silently returning an empty table. Only replicated engines honour the setting.
    */
+  protected def cloudReadSettingValues: Seq[String] =
+    if (isCloud) Seq("select_sequential_consistency=1") else Nil
+
   private def cloudReadSettings: Iterable[(String, String)] =
-    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
+    if (cloudReadSettingValues.isEmpty) Nil
+    else Seq(READ_SETTINGS_KEY -> cloudReadSettingValues.mkString(", "))
+
+  /**
+   * Read settings for a `withSQLConf(READ_SETTINGS_KEY -> ...)` override. The conf is single-valued,
+   * so overriding it outright would drop [[cloudReadSettingValues]] and let the read land on a
+   * replica that has not caught up.
+   */
+  protected def readSettingsWith(extra: String*): String =
+    (cloudReadSettingValues ++ extra).mkString(", ")
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -86,6 +86,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,9 +19,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -31,11 +29,6 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
-  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -459,7 +459,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
       // Tag the query so we can pull it from system.query_log by log_comment.
       val topNLogTag = java.util.UUID.randomUUID().toString
-      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith(s"log_comment='$topNLogTag'")) {
         checkAnswer(
           spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
           Seq(Row(40L), Row(30L))

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,9 +17,7 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -30,11 +28,6 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
-  // caught up with a recent write. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -36,6 +36,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     s"test_db_${timestamp}_${uuidPrefix}"
   }
 
+  protected val READ_SETTINGS_KEY = "spark.clickhouse.read.settings"
+
   protected def useSuiteLevelDatabase: Boolean = isCloud
 
   /**
@@ -101,8 +103,20 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
    * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
    * insert, silently returning an empty table. Only replicated engines honour the setting.
    */
+  protected def cloudReadSettingValues: Seq[String] =
+    if (isCloud) Seq("select_sequential_consistency=1") else Nil
+
   private def cloudReadSettings: Iterable[(String, String)] =
-    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
+    if (cloudReadSettingValues.isEmpty) Nil
+    else Seq(READ_SETTINGS_KEY -> cloudReadSettingValues.mkString(", "))
+
+  /**
+   * Read settings for a `withSQLConf(READ_SETTINGS_KEY -> ...)` override. The conf is single-valued,
+   * so overriding it outright would drop [[cloudReadSettingValues]] and let the read land on a
+   * replica that has not caught up.
+   */
+  protected def readSettingsWith(extra: String*): String =
+    (cloudReadSettingValues ++ extra).mkString(", ")
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -85,6 +85,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.clickhouse.SparkTest
 import org.apache.spark.sql.functions.month
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
 import java.util.UUID
 import scala.util.{Failure, Success, Try}
@@ -35,6 +37,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
   }
 
   protected def useSuiteLevelDatabase: Boolean = isCloud
+
+  /**
+   * Cloud's multi-replica compute can serve a read from a replica whose part or mutation cache has
+   * not yet caught up with a recent write or DELETE. Retries `body` until reads converge, and runs
+   * it once unchanged when not on Cloud.
+   */
+  protected def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,9 +19,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -31,11 +29,6 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
-  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -459,7 +459,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
       // Tag the query so we can pull it from system.query_log by log_comment.
       val topNLogTag = java.util.UUID.randomUUID().toString
-      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith(s"log_comment='$topNLogTag'")) {
         checkAnswer(
           spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
           Seq(Row(40L), Row(30L))

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,9 +17,7 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -30,11 +28,6 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
-  // caught up with a recent write. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.clickhouse.SparkTest
 import org.apache.spark.sql.functions.month
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
 import java.util.UUID
 import scala.util.{Failure, Success, Try}
@@ -36,6 +38,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
   }
 
   protected def useSuiteLevelDatabase: Boolean = isCloud
+
+  /**
+   * Cloud's multi-replica compute can serve a read from a replica whose part or mutation cache has
+   * not yet caught up with a recent write or DELETE. Retries `body` until reads converge, and runs
+   * it once unchanged when not on Cloud.
+   */
+  protected def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -37,6 +37,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     s"test_db_${timestamp}_${uuidPrefix}"
   }
 
+  protected val READ_SETTINGS_KEY = "spark.clickhouse.read.settings"
+
   protected def useSuiteLevelDatabase: Boolean = isCloud
 
   /**
@@ -102,8 +104,20 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
    * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
    * insert, silently returning an empty table. Only replicated engines honour the setting.
    */
+  protected def cloudReadSettingValues: Seq[String] =
+    if (isCloud) Seq("select_sequential_consistency=1") else Nil
+
   private def cloudReadSettings: Iterable[(String, String)] =
-    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
+    if (cloudReadSettingValues.isEmpty) Nil
+    else Seq(READ_SETTINGS_KEY -> cloudReadSettingValues.mkString(", "))
+
+  /**
+   * Read settings for a `withSQLConf(READ_SETTINGS_KEY -> ...)` override. The conf is single-valued,
+   * so overriding it outright would drop [[cloudReadSettingValues]] and let the read land on a
+   * replica that has not caught up.
+   */
+  protected def readSettingsWith(extra: String*): String =
+    (cloudReadSettingValues ++ extra).mkString(", ")
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -86,6 +86,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,9 +19,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -31,11 +29,6 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
-  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -94,7 +94,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -102,7 +104,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -126,7 +130,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      eventuallyOnCloud {
+        spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -134,7 +140,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      eventuallyOnCloud {
+        spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
+      }
       eventuallyOnCloud {
         checkAnswer(
           spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
@@ -175,15 +183,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22")) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("date=2022-04-11"),
-          Row("date=2022-04-12"),
-          Row("date=2022-04-21"),
-          Row("date=2022-04-22")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("date=2022-04-11"),
+            Row("date=2022-04-12"),
+            Row("date=2022-04-21"),
+            Row("date=2022-04-22")
+          )
         )
-      )
+      }
     }
   }
 
@@ -221,15 +231,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, "two_two", "2", 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=1/part_2=1"),
-          Row("part_1=1/part_2=2"),
-          Row("part_1=2/part_2=1"),
-          Row("part_1=2/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=1/part_2=1"),
+            Row("part_1=1/part_2=2"),
+            Row("part_1=2/part_2=1"),
+            Row("part_1=2/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -264,15 +276,17 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(22L, date("2022-04-22"), 2) :: Nil
       )
 
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(
-          Row("part_1=2022-04-11/part_2=1"),
-          Row("part_1=2022-04-12/part_2=2"),
-          Row("part_1=2022-04-21/part_2=1"),
-          Row("part_1=2022-04-22/part_2=2")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(
+            Row("part_1=2022-04-11/part_2=1"),
+            Row("part_1=2022-04-12/part_2=2"),
+            Row("part_1=2022-04-21/part_2=1"),
+            Row("part_1=2022-04-22/part_2=2")
+          )
         )
-      )
+      }
     }
   }
 
@@ -296,13 +310,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (2L, "2022-06-07")
       )).toDF("id", "dt")
         .writeTo(s"$db.$tbl").append
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
-        Seq(
-          Row("dt=20220606"),
-          Row("dt=20220607")
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+          Seq(
+            Row("dt=20220606"),
+            Row("dt=20220607")
+          )
         )
-      )
+      }
       checkAnswer(
         spark.table(s"$db.$tbl").orderBy($"id"),
         Seq(

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -459,7 +459,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
       // Tag the query so we can pull it from system.query_log by log_comment.
       val topNLogTag = java.util.UUID.randomUUID().toString
-      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith(s"log_comment='$topNLogTag'")) {
         checkAnswer(
           spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
           Seq(Row(40L), Row(30L))

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -28,6 +30,11 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
+  // caught up with a recent write. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>
@@ -83,9 +90,14 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   test("reading a table with multiple partitions does not warn about single partition read") {
     withSimpleTable("db_read_warning", "tbl_multi_part", writeData = true) { (db, tbl) =>
-      val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
-      assert(rowCount === 2)
-      assert(!warnings.exists(_.contains("as a single partition")))
+      // The warning is driven by the partition listing from `system.parts`, which is eventually
+      // consistent on Cloud: a listing that has not caught up looks like a single-partition table.
+      // Re-read until it converges; captureWarnings starts a fresh capture on each attempt.
+      eventuallyOnCloud {
+        val (rowCount, warnings) = captureWarnings(batchScanLogger)(readRowCount(db, tbl))
+        assert(rowCount === 2)
+        assert(!warnings.exists(_.contains("as a single partition")))
+      }
     }
   }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReadWarningSuite.scala
@@ -17,9 +17,7 @@ package org.apache.spark.sql.clickhouse.single
 import com.clickhouse.spark.Log4j2CaptureHelper
 import com.clickhouse.spark.base.{ClickHouseCloudMixIn, ClickHouseSingleMixIn}
 import org.apache.spark.sql.Row
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
-import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudReadWarningSuite extends ClickHouseReadWarningSuite with ClickHouseCloudMixIn
@@ -30,11 +28,6 @@ abstract class ClickHouseReadWarningSuite extends SparkClickHouseSingleTest with
 
   private val engineUtilsLogger = "com.clickhouse.spark.spec.TableEngineUtils"
   private val batchScanLogger = "com.clickhouse.spark.read.ClickHouseBatchScan"
-
-  // Cloud's multi-replica compute can serve reads from a replica whose part cache has not yet
-  // caught up with a recent write. Retry the assertion until reads converge.
-  private def eventuallyOnCloud(body: => Unit): Unit =
-    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("reading a view does not warn about unknown table engine") {
     withKVTable("db_read_warning", "tbl_view_src", valueColDef = "String") { (db, tbl) =>

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
@@ -1308,8 +1308,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
 
       // Disable CH's default integer-quoting in JSON output so VariantBuilder.parseJson
       // round-trips integer paths as Int, not ShortString.
-      spark.conf.set("spark.clickhouse.read.settings", "output_format_json_quote_64bit_integers=0")
-      try {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith("output_format_json_quote_64bit_integers=0")) {
         val df = spark.table(s"$actualDb.$actualTbl").orderBy("id")
         val result = df.collect()
         assert(result.length == 2)
@@ -1320,8 +1319,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         val m1 = result(1).getMap[String, VariantVal](1)
         assert(m1.keySet == Set("only"))
         assert(variantToJson(m1("only")) == """{"v":99}""")
-      } finally
-        spark.conf.unset("spark.clickhouse.read.settings")
+      }
     }
   }
 
@@ -1391,8 +1389,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
 
       // Disable CH's default integer-quoting in JSON output so VariantBuilder.parseJson
       // round-trips integer paths as Int, not ShortString.
-      spark.conf.set("spark.clickhouse.read.settings", "output_format_json_quote_64bit_integers=0")
-      try {
+      withSQLConf(READ_SETTINGS_KEY -> readSettingsWith("output_format_json_quote_64bit_integers=0")) {
         val df = spark.table(s"$actualDb.$actualTbl").orderBy("id")
         val result = df.collect()
         assert(result.length == 1)
@@ -1402,8 +1399,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         assert(variantToJson(arr(0).get(1).asInstanceOf[VariantVal]) == """{"x":1}""")
         assert(arr(1).getString(0) == "second")
         assert(variantToJson(arr(1).get(1).asInstanceOf[VariantVal]) == """{"x":2}""")
-      } finally
-        spark.conf.unset("spark.clickhouse.read.settings")
+      }
     }
   }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -35,6 +35,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     s"test_db_${timestamp}_${uuidPrefix}"
   }
 
+  protected val READ_SETTINGS_KEY = "spark.clickhouse.read.settings"
+
   protected def useSuiteLevelDatabase: Boolean = isCloud
 
   /**
@@ -101,8 +103,20 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
    * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
    * insert, silently returning an empty table. Only replicated engines honour the setting.
    */
+  protected def cloudReadSettingValues: Seq[String] =
+    if (isCloud) Seq("select_sequential_consistency=1") else Nil
+
   private def cloudReadSettings: Iterable[(String, String)] =
-    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
+    if (cloudReadSettingValues.isEmpty) Nil
+    else Seq(READ_SETTINGS_KEY -> cloudReadSettingValues.mkString(", "))
+
+  /**
+   * Read settings for a `withSQLConf(READ_SETTINGS_KEY -> ...)` override. The conf is single-valued,
+   * so overriding it outright would drop [[cloudReadSettingValues]] and let the read land on a
+   * replica that has not caught up.
+   */
+  protected def readSettingsWith(extra: String*): String =
+    (cloudReadSettingValues ++ extra).mkString(", ")
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -85,6 +85,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.clickhouse.write.write.repartitionNum", "0")
     .set("spark.clickhouse.read.format", "json")
     .set("spark.clickhouse.write.format", "json")
+    .setAll(cloudReadSettings)
+
+  /**
+   * On Cloud a read may be routed to a replica that has not yet caught up with a just-committed
+   * insert, silently returning an empty table. Only replicated engines honour the setting.
+   */
+  private def cloudReadSettings: Iterable[(String, String)] =
+    if (isCloud) Seq("spark.clickhouse.read.settings" -> "select_sequential_consistency=1") else Nil
 
   override def cmdRunnerOptions: Map[String, String] = Map(
     "host" -> clickhouseHost,

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.clickhouse.SparkTest
 import org.apache.spark.sql.functions.month
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
 import java.util.UUID
 
@@ -34,6 +36,14 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
   }
 
   protected def useSuiteLevelDatabase: Boolean = isCloud
+
+  /**
+   * Cloud's multi-replica compute can serve a read from a replica whose part or mutation cache has
+   * not yet caught up with a recent write or DELETE. Retries `body` until reads converge, and runs
+   * it once unchanged when not on Cloud.
+   */
+  protected def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   override def beforeAll(): Unit = {
     super.beforeAll()


### PR DESCRIPTION
Tests only — no production code touched.

The nightly ClickHouse Cloud job failed **26 of the last 30 runs**: all 13 matrix jobs, on a different random set of tests each night. The service is one endpoint backed by three replicas, and the connector opens a fresh `NodeClient` per operation, so consecutive calls are served by different, independently-lagging replicas.

**Reads could hit a replica that hadn't caught up** and silently return an empty table (`Array() had length 0`). From `system.query_log` for the failing `decode IPv4` test: the insert landed on `svocwnp`; reads on `svocwnp` and `nqojoyp` returned 3 rows, the read on `jzgtt5a` returned 0. Over one nightly window `jzgtt5a` served 76 zero-row reads out of 3,307 while the other two served none.

Fixed by requesting `select_sequential_consistency=1` for Cloud reads via `spark.clickhouse.read.settings` — a session-level conf applied to the scan SQL, so it covers both read paths the suites use (the catalog path and `spark.read.format("clickhouse")`, which sets no `clickhouse_setting_*` options of its own). Gated on `isCloud`, since only replicated engines honour it. Measured over 100 iterations of create → async insert → immediate read: **6/100 stale by default, 0/100 with the setting.**

**`SHOW PARTITIONS` and `DROP`/`TRUNCATE PARTITION`** resolve partitions through `system.parts`, which during a nightly run returned 0, 1 or 2 partitions for the same table within the same second — from all three replicas, not one lagging one. A metadata listing reflecting the serving replica's view is the consistency model rather than a defect, and there's no cheap primitive that fixes it (enumerating from the table instead is correct but scans it: 20M rows / 152 MiB measured on a 20M-row table). So these assertions now use the suite's existing `eventuallyOnCloud` — most already did, these were the spots that were missed. The mutating DDL is wrapped too, so a stale precondition check retries instead of failing.

The single-partition read warning comes from the same listing and is wrapped likewise. Retrying is sound because each attempt resamples — `readRowCount` re-plans the scan over a new connection, and `captureWarnings` attaches a fresh appender per invocation.

`eventuallyOnCloud` is a pass-through off Cloud, so single-node runs are unaffected. The second commit consolidates it into `SparkClickHouseSingleTest`, which already owns the Cloud-conditional test behaviour, replacing two copies.

Verified locally on all four Spark versions: 329/350/350/409 integration tests, 0 failures, style clean.
